### PR TITLE
Added penalize to failed Site-to-Site flows

### DIFF
--- a/nifi-put-site-to-site-processors/src/main/java/com/joeyfrazee/nifi/processors/PutSiteToSite.java
+++ b/nifi-put-site-to-site-processors/src/main/java/com/joeyfrazee/nifi/processors/PutSiteToSite.java
@@ -213,6 +213,7 @@ public class PutSiteToSite extends AbstractProcessor {
         }
         catch (Exception e) {
           getLogger().error("Site-to-site transfer to {} at {} failed for FlowFile {}", new Object[]{remoteInputPort, remoteUrl, flowFile}, e);
+          flowFile = session.penalize(flowFile);
           session.transfer(flowFile, REL_FAILURE);
           return;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.5.1</version>
+        <version>0.6.0</version>
     </parent>
 
     <groupId>com.joeyfrazee.nifi</groupId>


### PR DESCRIPTION
This may have been a deliberate decision, but I was wondering why there is no penalty on failed FlowFiles for the PutSiteToSite processor. 

I found this in a failure scenario (incorrect configuration on the other end) that retries on a failure rel loopback were causing a lot of stress and logging, so added a penalize call to make the retry effectively configurable in the Processor.

Looking at the design, it may have been deliberately left out to ensure immediate retry, but that could also be achieved with a zero penalty duration setting.
